### PR TITLE
Use docker config.json creds where available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module foxygo.at/dreg
 go 1.16
 
 require (
-	foxygo.at/protog v0.0.8
+	foxygo.at/protog v0.0.9
 	github.com/alecthomas/kong v0.2.17
 	github.com/dustin/go-humanize v1.0.0
 	google.golang.org/genproto v0.0.0-20210824181836-a4879c3d0e89

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 foxygo.at/protog v0.0.8 h1:dLsUHgCQB3O5iM9z+5zhAoPC34PMIuYYKjW3uhopELA=
 foxygo.at/protog v0.0.8/go.mod h1:tbP95P714D3rMmfp9f48bQ0555Wcdx5C0BFTdvQpCc4=
+foxygo.at/protog v0.0.9 h1:WRZcTd2QMcv0LqjGU6cU5wXHCsj2qFtjLSxYZ+i3i9o=
+foxygo.at/protog v0.0.9/go.mod h1:tbP95P714D3rMmfp9f48bQ0555Wcdx5C0BFTdvQpCc4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/kong v0.2.17 h1:URDISCI96MIgcIlQyoCAlhOmrSw6pZScBNkctg8r0W0=


### PR DESCRIPTION
Use credentials from `~/.docker/config.json`, generated from the
`docker login` command. This allows access to registries that require
authentication.